### PR TITLE
Fix python 3.10 error

### DIFF
--- a/Tooltip.py
+++ b/Tooltip.py
@@ -585,7 +585,9 @@ def showTooltip(text, background_color, tooltip_textColor, button_width, button_
     p.setColor(QPalette.WindowText, QColor("transparent"))
     lab.setPalette(p)
     if tooltip_style == 0:
-        lab.move(aw.mapToGlobal(QPoint(x_offset+(aw.width()-button_width)/2, y_offset+aw.height())))
+        x_coordinate = int(x_offset+(aw.width()-button_width)/2)
+        y_coordinate = y_offset+aw.height()
+        lab.move(aw.mapToGlobal(QPoint(x_coordinate, y_coordinate)))
     else:
         x_coordinate = min(x_offset, aw.width())
         y_coordinate = min(y_offset, aw.height())


### PR DESCRIPTION
Hi, thanks for this addon!

On Python 3.10, clicking on the button will bring up the following error message:

```
Anki 2.1.49 (dc80804a) Python 3.10.0 Qt 5.15.2 PyQt 5.15.6
Platform: Linux
Flags: frz=False ao=True sv=2
Add-ons, last update check: 2021-12-14 [...]
相关扩展:Advanced Review Bottom Bar

Caught exception:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/aqt/webview.py", line 41, in cmd
    return json.dumps(self.onCmd(str))
  File "/usr/local/lib/python3.10/site-packages/aqt/webview.py", line 142, in _onCmd
    return self._onBridgeCmd(str)
  File "/usr/local/lib/python3.10/site-packages/aqt/webview.py", line 595, in _onBridgeCmd
    return self.onBridgeCmd(cmd)
  File "/[...]/.local/share/Anki2/addons21/1136455830/Bottom_Bar.py", line 107, in linkHandler_wrap
    Review_linkHandelr_Original(reviewer, url)
  File "/usr/local/lib/python3.10/site-packages/aqt/reviewer.py", line 503, in _linkHandler
    self._answerCard(val)
  File "/usr/lib/python3.10/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/usr/local/lib64/python3.10/site-packages/anki/hooks.py", line 89, in decorator_wrapper
    return repl(*args, **kwargs)
  File "/usr/local/lib64/python3.10/site-packages/anki/hooks.py", line 83, in repl
    new(*args, **kwargs)
  File "/[...]/.local/share/Anki2/addons21/1136455830/Tooltip.py", line 550, in myTooltip
    showTooltip(text, background_color, tooltip_textColor, button_width, button_height, x_offset, y_offset, period=tooltip_timer)
  File "/[...]/.local/share/Anki2/addons21/1136455830/Tooltip.py", line 588, in showTooltip
    lab.move(aw.mapToGlobal(QPoint(x_offset+(aw.width()-button_width)/2, y_offset+aw.height())))
TypeError: arguments did not match any overloaded call:
  QPoint(): too many arguments
  QPoint(int, int): argument 1 has unexpected type 'float'
  QPoint(QPoint): argument 1 has unexpected type 'float'
```

Seems `QPoint(int, int)` only accept `int` but `x_offset+(aw.width()-button_width)/2` is a `float` type, so I manually convert it to int.