### PR TITLE
Fix bottom bar being cut off

### DIFF
--- a/Bottom_Bar.py
+++ b/Bottom_Bar.py
@@ -294,9 +294,9 @@ def _bottomHTML(self):
 %(right_side2)s
 %(right_side3)s
 %(right_side4)s
-<td width=50 align=right valign=top class=stat style='color: %(time_color)s'><span id=time class=stattxt>
-</span><br>
-<button onclick="pycmd('more');" %(more_style)s>%(more_label)s %(downArrow)s</button>
+<td width=50 align=right valign=top class=stat style='color: %(time_color)s'><br>
+<button onclick="pycmd('more');" %(more_style)s>%(more_label)s %(downArrow)s <span id=time class=stattxt>
+</span></button>
 </td>
 </tr>
 </table>
@@ -350,12 +350,13 @@ def _showAnswerButton(self):
             self.bottom.web.eval("setAutoAlert(%d);" % (c['autoAlert'] * 1000))
     middle = '''
 <table cellspacing=0 cellpadding=0><tr><td class=stat2 align=center>
-<span class=stattxt> %(remaining)s </span><br>
+<br>
 %(middleLeft_side1)s
 %(middleLeft_side2)s
 %(middleLeft_side3)s
 %(middleLeft_side4)s
-<button title="Shortcut key: Space" onclick='pycmd("ans");' %(answer_style)s>%(showAnswer_text)s</button>
+<button title="Shortcut key: Space" onclick='pycmd("ans");' %(answer_style)s>%(showAnswer_text)s
+    <span class="stattxt"> %(remaining)s </span></button>
 %(middleRight_side1)s
 %(middleRight_side2)s
 %(middleRight_side3)s

--- a/Button_Colors.py
+++ b/Button_Colors.py
@@ -197,8 +197,8 @@ def _answerButtons(self):
         else:
             bottombar_table = ""
         return style + button_styles + '''
-<td align=center>{0}
-<button title="Shortcut Key: {1}" data-ease="{1}" onclick='pycmd("ease{1}");' class={2} id={3} {4}>{5}{6}</button>
+<td align=center><br>
+<button title="Shortcut Key: {1}" data-ease="{1}" onclick='pycmd("ease{1}");' class={2} id={3} {4}>{5}{6} {0}</button>
 </td>'''.format(due, i, button_class, button_id, extra, label, inButton_due)
     #// adjusting the answer button table for wide button
     if button_style == 2 or button_style == 3:


### PR DESCRIPTION
With Anki
```
Version ⁨2.1.55 (01caec2a)⁩
Python 3.9.15 Qt 6.3.2 PyQt 6.3.1
```

This is just a quick fix (#48 maybe #47) only tested for me. It would require feedback from many users with different anki versions.

I’ve just noticed that `.stattxt` & `.nobold` elements were inside the correspondig buttons in Anki DOM.
I made the change with the DOM generated by the plugin and it’s now readable again.

![due](https://user-images.githubusercontent.com/4688434/210972868-da3e1ebf-dfab-44e1-9b6d-4ca55a9d6050.jpg)
![answer](https://user-images.githubusercontent.com/4688434/210972895-4a035d1f-44f6-40e3-aa9a-823011ad7910.jpg)

This PR is mainly for helping you spotting where the problem is, and making better changes based on your better knowledge of your plugin, and for people wanting to tweak manually their files, fixing temporarily their interface, not really for merging.